### PR TITLE
[Feat/#3] Declaration Files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,7 @@
-const hello = () => "hi";
+import { init, exit } from "myPackage";
+
+init({
+  urls: "true",
+});
+
+exit(1);

--- a/src/myPackage.d.ts
+++ b/src/myPackage.d.ts
@@ -1,0 +1,8 @@
+interface Config {
+  urls: string;
+}
+
+declare module "myPackage" {
+  function init(config: Config): boolean; // true로 리턴하기 때문
+  function exit(code: number): number; // code + 1로 리턴하기 때문
+}

--- a/src/myPackage.js
+++ b/src/myPackage.js
@@ -1,0 +1,7 @@
+export function init(config) {
+  return true;
+}
+
+export function exit(code) {
+  return code + 1;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "build",
     "target": "ES6", // 어떤 자바스크립트로 컴파일할지 알려준다.
-    "lib": ["ES6", "DOM"]
+    "lib": ["ES6", "DOM"],
+    "strict": true
   }
 }


### PR DESCRIPTION
타입 정의는 타입스크립트에게 몇몇 자바스크립트 코드의 타입을 설명해주기 위해 사용되는건데, 자바스크립트 코드와 API의 타입을 설명해주기 위해 사용한다.

모듈 하나를 선언해서 타입 정의를 하거나 lib.dom.d.ts에서 설명해놓은 정의 방법을 적어서 타입 정의하는 두 가지 방법을 통해 우리가 모양이나 구조를 설명하면 타입스크립트가 우리가 사용하는 모양을 찾아내서 자바스크립트 코드를 작성하게 도와준다.